### PR TITLE
[DATAVIC-85] Bypass CKAN core bug not showing organisations on dashbo…

### DIFF
--- a/ckanext/datavicmain/templates/user/dashboard_organizations.html
+++ b/ckanext/datavicmain/templates/user/dashboard_organizations.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  <h2 class="hide-heading">{{ _('My Organizations') }}</h2>
+  {% set organizations = h.organizations_available('manage_group') %}
+  {% if organizations %}
+    <div class="wide">
+      {% snippet "organization/snippets/organization_list.html", organizations=organizations %}
+    </div>
+  {% else %}
+    <p class="empty">
+      {{ _('You are not a member of any organizations.') }}
+      {% if h.check_access('organization_create') %}
+        {% link_for _('Create one now?'), controller='organization', action='new' %}
+      {% endif %}
+    </p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
…ard for non-admin users.

This PR is a simple fix for a bug in CKAN core that wasn't resolved until v2.7.0

As an editor user, when logging in and accessing the Dashboard > My Organisations -- no organisations were being shown due to an incorrect permission ('edit_group') being defaulted to.

This PR resolves this issue via a template override for the Dashboard Organisations page which pushes in a valid user permission.
