### PR TITLE
[DATAVIC-56] Hide CKAN visibility field.

### DIFF
--- a/ckanext/datavicmain/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/datavicmain/templates/package/snippets/package_basic_fields.html
@@ -20,6 +20,9 @@ Add widgets for our basic custom (extension-specific) fields
 
 {% endblock %}
 
+{% block package_metadata_fields_visibility %}
+{% endblock %}
+
 {% block package_basic_fields_custom %}
 
   {{ super() }}


### PR DESCRIPTION
Hides/removes the "Visibility" field on dataset form.

@sonnykt -- this change needs to be hotfix into UAT when possible for Jim to respond to client.

Cheers,
Nathan.