### PR TITLE
[DATAVIC-81] Remove `temporal_range_coverage` and `release_date` fiel…

### DIFF
--- a/ckanext/datavicmain/plugins.py
+++ b/ckanext/datavicmain/plugins.py
@@ -79,11 +79,9 @@ class DatasetForm(p.SingletonPlugin, toolkit.DefaultDatasetForm):
         ('asgs', {'label': 'ASGS (Australian Statistical Geography Standard)'}),
         ('bounding_box', {'label': 'Bounding Box'}),
         ('vertical_coverage', {'label': 'Vertical Coverage'}),
-        ('temporal_range_coverage', {'label': 'Temporal Range/Coverage'}),
         ('data_quality_trust_statement', {'label': 'Data Quality / Trust Statement'}),
         ('period_start', {'label': 'Temporal Coverage Start'}),
         ('period_end', {'label': 'Temporal Coverage End'}),
-        ('release_date', {'label': 'Release Date'}),
     ]
 
     # Format (tuple): ( 'field_id', { 'field_attribute': 'value' } )
@@ -443,8 +441,6 @@ class DatasetForm(p.SingletonPlugin, toolkit.DefaultDatasetForm):
             'period_start': [toolkit.get_converter('convert_from_extras'),
                              toolkit.get_validator('ignore_missing')],
             'period_end': [toolkit.get_converter('convert_from_extras'),
-                           toolkit.get_validator('ignore_missing')],
-            'release_date': [toolkit.get_converter('convert_from_extras'),
                            toolkit.get_validator('ignore_missing')],
         })
 

--- a/ckanext/datavicmain/templates/package/snippets/resource_item.html
+++ b/ckanext/datavicmain/templates/package/snippets/resource_item.html
@@ -10,8 +10,8 @@
   {% if h.is_historical() or url_is_edit %}
   <p>
     <small>
-        {% if res.release_date and res.release_date != '' %}
-        Release Date: {{res.release_date|truncate(10,end='')}} &nbsp;
+        {% if res.public_release_date and res.public_release_date != '' %}
+        Release Date: {{res.public_release_date|truncate(10,end='')}} &nbsp;
         {% endif %}
         {% if res.period_start and res.period_start != '' %}
         Period: {{res.period_start|truncate(10,end='')}} &raquo; {{res.period_end|truncate(10,end='')}}


### PR DESCRIPTION
…ds from updated resource schema.

Hi @sonnykt 

This PR makes a couple of small tweaks to the historical records work:

1. It removes a field named `temporal_range_coverage` from the updated resource schema that was added prior to implementing historical records, and...

2. It removes a field named `release_date`, which was added as part of implementing historical records, but is not required as there was already a field named `public_release_date` added in to the resource schema.

Could you please review and merge when possible, then I will create a PR to merge into main repo.

Thanks,
Nathan.