### PR TITLE
[DATAVIC-87] Add additional resource format config setting to admin a…

### DIFF
--- a/ckanext/datavicmain/templates/admin/config.html
+++ b/ckanext/datavicmain/templates/admin/config.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block admin_form %}
+    {{ super() }}
+    {{ form.textarea(
+        'ckan.datavic.authorised_resource_formats',
+        id='field-ckan.datavic.authorised_resource_formats',
+        label=_('Additional Resource Formats'),
+        value=data['ckan.datavic.authorised_resource_formats'],
+        error=errors['ckan.datavic.authorised_resource_formats']) }}
+{% endblock %}

--- a/ckanext/datavicmain/templates/package/snippets/resource_form.html
+++ b/ckanext/datavicmain/templates/package/snippets/resource_form.html
@@ -1,5 +1,24 @@
 {% ckan_extends %}
 
+  {% block basic_fields_format %}
+    {% if h.is_sysadmin() %}
+      {% set format_attrs = {'data-module': 'autocomplete', 'data-module-source': '/api/2/util/resource/format_autocomplete?incomplete=?'} %}
+      {% call form.input('format', id='field-format', label=_('Format'), placeholder=_('eg. CSV, XML or JSON'), value=data.format, error=errors.format, classes=['control-medium'], attrs=format_attrs) %}
+        <span class="info-block info-block-small">
+          <i class="icon-info-sign"></i>
+          {{ _('This will be guessed automatically. Leave blank if you wish') }}
+        </span>
+      {% endcall %}
+    {% else %}
+      {% call form.select('format', id='field-format', label=_('Format'), options=h.get_formats(100), selected=data.format|lower, error=errors.format, classes=['inp-holder']) %}
+        <span class="info-block info-block-small">
+          <i class="icon-info-sign"></i>
+          {{ _("Please enter 'api/tool' as the format for APIs or data tools.") }}
+        </span>
+      {% endcall %}
+    {% endif %}
+  {% endblock %}
+
 {% block metadata_fields %}
 
   {% for field_id, field_attributes in h.resource_extra_fields %}


### PR DESCRIPTION
…rea and use to render format options for non-sysadmin users.

Hi @sonnykt 

This PR introduces a new run-time manageable configuration setting in the sysadmin config panel (additional resource formats), which is used to control the select list of resource formats in the front-end for non-sysadmin users.

Could you please review & merge?

Many thanks,
Nathan.