### PR TITLE
[DATAVIC-97] Template updates for dataset created & modified date display

### DIFF
--- a/ckanext/datavicmain/plugins.py
+++ b/ckanext/datavicmain/plugins.py
@@ -44,6 +44,21 @@ def parse_date(date_str):
         return None
 
 
+def release_date(pkg_dict):
+    """
+    Copied from https://github.com/salsadigitalauorg/datavic_ckan_2.2/blob/develop/iar/src/ckanext-datavic/ckanext/datavic/plugin.py#L296
+    :param pkg_dict:
+    :return:
+    """
+    dates = []
+    dates.append(pkg_dict['metadata_created'])
+    for resource in pkg_dict['resources']:
+        if 'release_date' in resource and resource['release_date'] != '' and resource['release_date'] != '1970-01-01':
+            dates.append(resource['release_date'])
+    dates.sort()
+    return dates[0].split("T")[0]
+
+
 def validator_email_not_in_use(user_email, context):
     user = context['user_obj']
 
@@ -350,7 +365,8 @@ class DatasetForm(p.SingletonPlugin, toolkit.DefaultDatasetForm):
             'repopulate_user_role': self.repopulate_user_role,
             'group_list': self.group_list,
             'get_option_label': custom_schema.get_option_label,
-            'autoselect_workflow_status_option': self.autoselect_workflow_status_option
+            'autoselect_workflow_status_option': self.autoselect_workflow_status_option,
+            'release_date': release_date,
         }
 
     ## IConfigurer interface ##

--- a/ckanext/datavicmain/templates/package/snippets/additional_info.html
+++ b/ckanext/datavicmain/templates/package/snippets/additional_info.html
@@ -34,20 +34,21 @@
             <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
           </tr>
         {% endif %}
-        {% if pkg_dict.metadata_modified %}
+        {% if pkg_dict.metadata_created %}
+          {% set release_date = h.release_date(pkg_dict) %}
           <tr>
-            <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
-            <td class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+            <th scope="row" class="dataset-label">{{ _("Published (Metadata Record)") }}</th>
+            <td class="dataset-details" property="dct:issued">
+              {{ release_date[8:] + '/' + release_date[5:7] + '/' + release_date[:4] }}
             </td>
           </tr>
         {% endif %}
-        {% if pkg_dict.metadata_created %}
+        {% if pkg_dict.metadata_modified %}
+          {% set metadata_modified = pkg_dict.metadata_modified.split("T")[0] %}
           <tr>
-            <th scope="row" class="dataset-label">{{ _("Published (Metadata Record)") }}</th>
-
-            <td class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
+            <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+            <td class="dataset-details" property="dct:updated">
+              {{ metadata_modified[8:] + '/' + metadata_modified[5:7] + '/' + metadata_modified[:4] }}
             </td>
           </tr>
         {% endif %}


### PR DESCRIPTION
Created/published data displayed on the dataset detail page is either the earliest resource `release_date` value, or falls back to the `metadata_created` value of the dataset.