### PR TITLE
[DATAVIC-108] Front-end updates for Public Release field.

### DIFF
--- a/ckanext/datavicmain/fantastic/datavicmain.js
+++ b/ckanext/datavicmain/fantastic/datavicmain.js
@@ -1,7 +1,21 @@
+function disable_enable_private_field() {
+    var organization_visibility = jQuery('#organization_visibility').val();
+    var workflow_status = jQuery('#workflow_status').val();
+    var disabled = !(organization_visibility === 'all' && workflow_status === 'published');
+    var private_field = jQuery('#field-private');
+    if (disabled) {
+        jQuery(private_field).val('True');
+    }
+    jQuery(private_field).prop('disabled', disabled);
+}
+
   jQuery(document).ready(function() {
     jQuery('#workflow_status').on('change', function() {
-        var workflow_status = jQuery(this).val();
-        jQuery('#field-private').prop('disabled', (workflow_status == 'published' ? false : true));
+        disable_enable_private_field();
+    });
+
+    jQuery('#organization_visibility').on('change', function() {
+        disable_enable_private_field();
     });
 
     jQuery('.calendar input').datepicker({

--- a/ckanext/datavicmain/templates/package/read.html
+++ b/ckanext/datavicmain/templates/package/read.html
@@ -2,7 +2,14 @@
 
 {# Note: The parent template has aliased c.pkg_dict as pkg #}
 
-{% block package_description %}    
+{% block package_description %}
+    {% if g.debug %}
+        {% if pkg.private %}
+            <p style="color: red;"><strong>Debug: This dataset is marked PRIVATE</strong></p>
+        {% else %}
+            <p style="color: green;"><strong>Debug: This dataset is marked PUBLIC</strong></p>
+        {% endif %}
+    {% endif %}
     <h1>
       {% block page_heading %}
        {{ super() }}

--- a/ckanext/datavicmain/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/datavicmain/templates/package/snippets/package_basic_fields.html
@@ -71,11 +71,14 @@ Add widgets for our basic custom (extension-specific) fields
       {{ _('Public Release') }}
     </label>
     <div class="controls">
-      <select id="field-private" name="private" {% if data.get('workflow_status') != 'published' %}disabled="true"{% endif %}>
+      <select id="field-private" name="private">
         {% for option in [('True', _('No')), ('False', _('Yes'))] %}
           <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
         {% endfor %}
       </select>
+      <span class="info-block info-inline">
+        <strong>Public Release</strong> can only be set to <strong>'Yes'</strong> if Workflow Status is 'Published' and Organisation Visibility is 'All'
+      </span>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
- Added javascript to disable Public Release field if Workflow Status != 'published' or 'Organization Visibility' != 'all'
- Added a debug message to display Private status on dataset detail page
- Added helper message on Public Release field