### PR TITLE
Hotfix/dcat json harvest issues

### DIFF
--- a/ckanext/datavicmain/plugins.py
+++ b/ckanext/datavicmain/plugins.py
@@ -498,6 +498,7 @@ class DatasetForm(p.SingletonPlugin, toolkit.DefaultDatasetForm):
                 data[('data_owner',)] = helpers.set_data_owner(data.get(('owner_org',), None))
             pass
 
+        # Only apply this logic when updating through the UI, otherwise it causes DCAT JSON harvests to fail
         if toolkit.c.controller == 'package':
             # Add our custom_resource_text metadata field to the schema
             # schema['resources'].update({


### PR DESCRIPTION
This PR adds a change to disable the custom schema being implemented for harvest originating datasets, as it was causing an issue when DCAT JSON harvests were updating on subsequent harvests after the initial harvest.