### PR TITLE
[DATAVIC-822] Purging DELWP Detached Datasets

### DIFF
--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -31,6 +31,9 @@ from ckanext.datastore.backend import get_all_resources_ids_in_datastore
 from ckanext.harvest.model import HarvestObject, HarvestSource
 
 from ckanext.datavicmain.helpers import field_choices
+from ckanext.syndicate.tasks import sync_package as syndicate_sync_package
+from ckanext.syndicate.types import Topic as SyndicateTopic
+from ckanext.syndicate import utils as syndicate_utils
 
 log = logging.getLogger(__name__)
 
@@ -1176,6 +1179,10 @@ class DeleteDetachedDelwpDatasets:
         for dataset in datasets:
             click.secho(f"Soft-deleting dataset {dataset.name}...", fg="blue")
             tk.get_action("package_delete")(context, {"id": dataset.id})
+
+            for profile in syndicate_utils.profiles_for(dataset):
+                click.secho(f"Sync soft deleted dataset to portal {profile.id}...", fg="blue")
+                syndicate_sync_package(dataset.id, SyndicateTopic.update, profile)
 
             click.secho(f"Purging dataset {dataset.name}...", fg="blue")
             tk.get_action("dataset_purge")(context, {"id": dataset.id})

--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -5,12 +5,15 @@ import csv
 import datetime
 import logging
 import mimetypes
+import os
 from itertools import groupby
 from os import path, stat
 from typing import Any
 from urllib.parse import urlparse
 
 import click
+import requests
+from requests.exceptions import RequestException
 import openpyxl
 import tqdm
 from sqlalchemy.orm import Query
@@ -1123,6 +1126,17 @@ class DeleteDetachedDelwpDatasets:
         click.secho(f"Found {len(datasets)} detached datasets", fg="blue")
         click.secho(f"Use --delete flag to delete them", fg="blue")
 
+        notify_url = (os.environ.get("MONITOR_DELWP_DETACHED_DATASETS_URL") or "").strip().rstrip("/")
+        if notify_url:
+            # Send failure notification if there are detached datasets.
+            target = f"{notify_url}/fail" if len(datasets) > 0 else notify_url
+            try:
+                click.secho(f"Monitoring service target: {target}", fg="green")
+                requests.get(target, timeout=10)
+                click.secho(f"Successfully notified monitoring service", fg="green")
+            except RequestException as e:
+                click.secho(f"Failed to notify monitoring service: {e}", fg="red")
+
     @classmethod
     def get_datasets(cls) -> set[model.Package]:
         package = model.Package
@@ -1154,13 +1168,16 @@ class DeleteDetachedDelwpDatasets:
     def purge_datasets(cls) -> None:
         datasets = cls.get_datasets()
 
-        click.secho(f"Purging {len(datasets)} datasets...", fg="blue")
+        click.secho(f"Soft-deleting then purging {len(datasets)} datasets...", fg="blue")
+
+        site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+        context = {"ignore_auth": True, "user": site_user["name"]}
 
         for dataset in datasets:
-            click.secho(f"Purging dataset {dataset.name}...", fg="blue")
+            click.secho(f"Soft-deleting dataset {dataset.name}...", fg="blue")
+            tk.get_action("package_delete")(context, {"id": dataset.id})
 
-            tk.get_action("dataset_purge")(
-                {"ignore_auth": True}, {"id": dataset.id}
-            )
+            click.secho(f"Purging dataset {dataset.name}...", fg="blue")
+            tk.get_action("dataset_purge")(context, {"id": dataset.id})
 
         click.secho(f"Done. {len(datasets)} datasets purged", fg="blue")

--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -1171,20 +1171,35 @@ class DeleteDetachedDelwpDatasets:
     def purge_datasets(cls) -> None:
         datasets = cls.get_datasets()
 
-        click.secho(f"Soft-deleting then purging {len(datasets)} datasets...", fg="blue")
+        # Collect IDs and names upfront. The Package objects will become
+        # detached from the SQLAlchemy session after dataset_purge commits
+        # and removes the session scope, causing DetachedInstanceError
+        # on lazy-loaded attributes (like .extras) in subsequent iterations.
+        dataset_refs = [(d.id, d.name) for d in datasets]
+
+        click.secho(f"Soft-deleting then purging {len(dataset_refs)} datasets...", fg="blue")
 
         site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
-        context = {"ignore_auth": True, "user": site_user["name"]}
 
-        for dataset in datasets:
-            click.secho(f"Soft-deleting dataset {dataset.name}...", fg="blue")
-            tk.get_action("package_delete")(context, {"id": dataset.id})
+        for dataset_id, dataset_name in dataset_refs:
+            click.secho(f"Soft-deleting dataset {dataset_name}...", fg="blue")
+            tk.get_action("package_delete")(
+                {"ignore_auth": True, "user": site_user["name"]},
+                {"id": dataset_id},
+            )
 
-            for profile in syndicate_utils.profiles_for(dataset):
-                click.secho(f"Sync soft deleted dataset to portal {profile.id}...", fg="blue")
-                syndicate_sync_package(dataset.id, SyndicateTopic.update, profile)
+            # Re-fetch after package_delete to get a session-bound instance
+            # with up-to-date state for syndication.
+            dataset = model.Package.get(dataset_id)
+            if dataset:
+                for profile in syndicate_utils.profiles_for(dataset):
+                    click.secho(f"Sync soft deleted dataset to portal {profile.id}...", fg="blue")
+                    syndicate_sync_package(dataset_id, SyndicateTopic.update, profile)
 
-            click.secho(f"Purging dataset {dataset.name}...", fg="blue")
-            tk.get_action("dataset_purge")(context, {"id": dataset.id})
+            click.secho(f"Purging dataset {dataset_name}...", fg="blue")
+            tk.get_action("dataset_purge")(
+                {"ignore_auth": True, "user": site_user["name"]},
+                {"id": dataset_id},
+            )
 
-        click.secho(f"Done. {len(datasets)} datasets purged", fg="blue")
+        click.secho(f"Done. {len(dataset_refs)} datasets purged", fg="blue")

--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -12,8 +12,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 import click
-import requests
-from requests.exceptions import RequestException
 import openpyxl
 import tqdm
 from sqlalchemy import or_
@@ -1152,16 +1150,10 @@ class DeleteDetachedDelwpDatasets:
         )
         click.secho("Use --delete flag to delete them", fg="blue")
 
-        notify_url = (os.environ.get("MONITOR_DELWP_DETACHED_DATASETS_URL") or "").strip().rstrip("/")
-        if notify_url:
-            # Send failure notification if there are detached datasets.
-            target = f"{notify_url}/fail" if len(datasets) > 0 else notify_url
-            try:
-                click.secho(f"Monitoring service target: {target}", fg="green")
-                requests.get(target, timeout=10)
-                click.secho("Successfully notified monitoring service", fg="green")
-            except RequestException as e:
-                click.secho(f"Failed to notify monitoring service: {e}", fg="red")
+        # Exit with non-zero status when detached datasets are found so the
+        # calling shell script can report to the monitoring service.
+        if datasets:
+            raise SystemExit(1)
 
     @classmethod
     def get_datasets(cls) -> set[model.Package]:

--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -16,12 +16,14 @@ import requests
 from requests.exceptions import RequestException
 import openpyxl
 import tqdm
+from sqlalchemy import or_
 from sqlalchemy.orm import Query
 
 import ckan.logic.validators as validators
 import ckan.model as model
 import ckan.plugins.toolkit as tk
 from ckan.lib.munge import munge_title_to_name
+from ckan.lib.search import clear as search_clear
 from ckan.lib.search import rebuild
 from ckan.lib.uploader import get_resource_uploader
 from ckan.model import Resource, ResourceView
@@ -31,9 +33,6 @@ from ckanext.datastore.backend import get_all_resources_ids_in_datastore
 from ckanext.harvest.model import HarvestObject, HarvestSource
 
 from ckanext.datavicmain.helpers import field_choices
-from ckanext.syndicate.tasks import sync_package as syndicate_sync_package
-from ckanext.syndicate.types import Topic as SyndicateTopic
-from ckanext.syndicate import utils as syndicate_utils
 
 log = logging.getLogger(__name__)
 
@@ -1104,12 +1103,19 @@ class ResourceFilesizeConvert:
 
 @maintain.command()
 @click.option("--delete", is_flag=True, type=click.BOOL, default=False)
-def delete_detached_delwp_datasets(delete: bool):
+@click.option(
+    "--csv-path",
+    default=None,
+    type=click.Path(),
+    help="Path for the CSV audit report.  "
+    "Defaults to /app/filestore/purge_reports/dd_delwp_purged_<timestamp>.csv",
+)
+def delete_detached_delwp_datasets(delete: bool, csv_path: str | None):
     """Delete DELWP datasets that are not attached to a harvest object"""
     if not delete:
         DeleteDetachedDelwpDatasets.list_detached_datasets()
     else:
-        DeleteDetachedDelwpDatasets.purge_datasets()
+        DeleteDetachedDelwpDatasets.purge_datasets(csv_path=csv_path)
 
 
 class DeleteDetachedDelwpDatasets:
@@ -1122,12 +1128,29 @@ class DeleteDetachedDelwpDatasets:
 
         datasets = cls.get_datasets()
 
+        active_count = 0
+        deleted_count = 0
+        other_count = 0
+
         for dataset in datasets:
             url = tk.url_for("dataset.read", id=dataset.name, _external=True)
-            click.secho(f"Dataset {url} is detached", fg="red")
+            click.secho(f"Dataset {url} is detached (state={dataset.state})", fg="red")
 
-        click.secho(f"Found {len(datasets)} detached datasets", fg="blue")
-        click.secho(f"Use --delete flag to delete them", fg="blue")
+            if dataset.state == model.State.ACTIVE:
+                active_count += 1
+            elif dataset.state == model.State.DELETED:
+                deleted_count += 1
+            else:
+                other_count += 1
+
+        click.secho(
+            f"Found {len(datasets)} detached datasets"
+            f" (active={active_count}, deleted={deleted_count}"
+            + (f", other={other_count}" if other_count else "")
+            + ")",
+            fg="blue",
+        )
+        click.secho("Use --delete flag to delete them", fg="blue")
 
         notify_url = (os.environ.get("MONITOR_DELWP_DETACHED_DATASETS_URL") or "").strip().rstrip("/")
         if notify_url:
@@ -1136,7 +1159,7 @@ class DeleteDetachedDelwpDatasets:
             try:
                 click.secho(f"Monitoring service target: {target}", fg="green")
                 requests.get(target, timeout=10)
-                click.secho(f"Successfully notified monitoring service", fg="green")
+                click.secho("Successfully notified monitoring service", fg="green")
             except RequestException as e:
                 click.secho(f"Failed to notify monitoring service: {e}", fg="red")
 
@@ -1152,12 +1175,15 @@ class DeleteDetachedDelwpDatasets:
 
         result = set()
 
+        # No state filter — detached DELWP datasets should be purged
+        # regardless of whether they are active, deleted, or in any other
+        # state.  They have no harvest object linking them to a source so
+        # they serve no purpose.
         for package in (
             model.Session.query(package)
             .join(extras, package.id == extras.package_id)
             .filter(extras.key == "harvest_source_type")
             .filter(extras.value == "delwp")
-            .filter(package.state == model.State.ACTIVE)
             .all()
         ):
             if package.id in packages_with_harvest_objects:
@@ -1168,38 +1194,214 @@ class DeleteDetachedDelwpDatasets:
         return result - packages_with_harvest_objects
 
     @classmethod
-    def purge_datasets(cls) -> None:
+    def purge_datasets(cls, csv_path: str | None = None) -> None:
+        import sys
+
         datasets = cls.get_datasets()
+        dataset_refs = [(d.id, d.name, d.state) for d in datasets]
 
-        # Collect IDs and names upfront. The Package objects will become
-        # detached from the SQLAlchemy session after dataset_purge commits
-        # and removes the session scope, causing DetachedInstanceError
-        # on lazy-loaded attributes (like .extras) in subsequent iterations.
-        dataset_refs = [(d.id, d.name) for d in datasets]
+        if not dataset_refs:
+            click.secho("No detached DELWP datasets found.", fg="green")
+            return
 
-        click.secho(f"Soft-deleting then purging {len(dataset_refs)} datasets...", fg="blue")
-
-        site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
-
-        for dataset_id, dataset_name in dataset_refs:
-            click.secho(f"Soft-deleting dataset {dataset_name}...", fg="blue")
-            tk.get_action("package_delete")(
-                {"ignore_auth": True, "user": site_user["name"]},
-                {"id": dataset_id},
+        # Collect syndicated_id extras for DD→DV cross-reference audit trail.
+        syndicated_ids: dict[str, str] = dict(
+            model.Session.query(
+                model.PackageExtra.package_id, model.PackageExtra.value
             )
-
-            # Re-fetch after package_delete to get a session-bound instance
-            # with up-to-date state for syndication.
-            dataset = model.Package.get(dataset_id)
-            if dataset:
-                for profile in syndicate_utils.profiles_for(dataset):
-                    click.secho(f"Sync soft deleted dataset to portal {profile.id}...", fg="blue")
-                    syndicate_sync_package(dataset_id, SyndicateTopic.update, profile)
-
-            click.secho(f"Purging dataset {dataset_name}...", fg="blue")
-            tk.get_action("dataset_purge")(
-                {"ignore_auth": True, "user": site_user["name"]},
-                {"id": dataset_id},
+            .filter(model.PackageExtra.key == "syndicated_id")
+            .filter(
+                model.PackageExtra.package_id.in_(
+                    [d[0] for d in dataset_refs]
+                )
             )
+            .all()
+        )
 
-        click.secho(f"Done. {len(dataset_refs)} datasets purged", fg="blue")
+        # Resolve CSV path — default to persistent filestore.
+        if not csv_path:
+            ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            csv_path = (
+                f"/app/filestore/purge_reports/dd_delwp_purged_{ts}.csv"
+            )
+        csv_dir = os.path.dirname(csv_path)
+        if csv_dir:
+            os.makedirs(csv_dir, exist_ok=True)
+
+        active_count = sum(
+            1 for _, _, s in dataset_refs if s == model.State.ACTIVE
+        )
+        deleted_count = sum(
+            1 for _, _, s in dataset_refs if s == model.State.DELETED
+        )
+        other_count = len(dataset_refs) - active_count - deleted_count
+
+        click.secho(
+            f"Purging {len(dataset_refs)} detached DELWP datasets"
+            f" (active={active_count}, deleted={deleted_count}"
+            + (f", other={other_count}" if other_count else "")
+            + f", {len(syndicated_ids)} have DV syndicated_id)...",
+            fg="blue",
+        )
+        sys.stdout.flush()
+
+        purged = 0
+        failed = 0
+
+        for dataset_id, dataset_name, _initial_state in dataset_refs:
+            try:
+                dv_id = syndicated_ids.get(dataset_id, "")
+                click.secho(
+                    f"  Purging {dataset_name}"
+                    + (f" (DV={dv_id})" if dv_id else ""),
+                    fg="blue",
+                )
+                sys.stdout.flush()
+
+                # 1. Clear from Solr index (works without package in DB).
+                search_clear(dataset_id)
+
+                # 2. Delete child rows that do NOT have DB-level
+                #    ON DELETE CASCADE.
+                #
+                #    Tables with DB-level CASCADE (auto-handled):
+                #      resource_view  → cascades from resource
+                #      user_following_dataset → cascades from package
+                #      harvest_object → cascades from package (migration)
+                model.Session.query(model.Resource).filter_by(
+                    package_id=dataset_id
+                ).delete()
+                model.Session.query(model.PackageExtra).filter_by(
+                    package_id=dataset_id
+                ).delete()
+                model.Session.query(model.PackageTag).filter_by(
+                    package_id=dataset_id
+                ).delete()
+                model.Session.query(model.PackageRelationship).filter(
+                    or_(
+                        model.PackageRelationship.subject_package_id
+                        == dataset_id,
+                        model.PackageRelationship.object_package_id
+                        == dataset_id,
+                    )
+                ).delete(synchronize_session="fetch")
+                model.Session.query(model.Member).filter(
+                    model.Member.table_id == dataset_id,
+                    model.Member.table_name == "package",
+                ).delete()
+                model.Session.query(model.PackageMember).filter_by(
+                    package_id=dataset_id
+                ).delete()
+
+                # 3. Delete the package row — triggers DB CASCADE for
+                #    resource_view, user_following_dataset, harvest_object.
+                model.Session.query(model.Package).filter_by(
+                    id=dataset_id
+                ).delete()
+                model.Session.commit()
+                purged += 1
+
+            except Exception as e:
+                click.secho(
+                    f"  ERROR purging {dataset_name}: {e}", fg="red"
+                )
+                log.error(
+                    "Failed to purge dataset %s (%s): %s",
+                    dataset_name,
+                    dataset_id,
+                    e,
+                )
+                model.Session.rollback()
+                failed += 1
+
+        # -- Post-purge: Solr orphan cleanup (safety net) ----------------
+        click.secho("\nCleaning up Solr orphaned entries...", fg="blue")
+        sys.stdout.flush()
+        try:
+            from ckan.cli.search_index import get_orphans
+
+            orphans = get_orphans()
+            for orphan_id in orphans:
+                search_clear(orphan_id)
+            if orphans:
+                click.secho(
+                    f"  Cleared {len(orphans)} orphaned Solr entries",
+                    fg="green",
+                )
+            else:
+                click.secho("  No orphaned Solr entries found", fg="green")
+        except Exception as e:
+            click.secho(
+                f"  WARNING: Solr orphan cleanup failed: {e}", fg="yellow"
+            )
+            log.warning("Solr orphan cleanup failed: %s", e)
+
+        # -- Post-purge: datastore orphan cleanup ------------------------
+        click.secho("Cleaning up orphaned datastore tables...", fg="blue")
+        sys.stdout.flush()
+        try:
+            site_user = tk.get_action("get_site_user")(
+                {"ignore_auth": True}, {}
+            )
+            ds_dropped = 0
+            for resid in get_all_resources_ids_in_datastore():
+                try:
+                    tk.get_action("resource_show")(
+                        {"user": site_user["name"]}, {"id": resid}
+                    )
+                except (tk.ObjectNotFound, KeyError):
+                    try:
+                        tk.get_action("datastore_delete")(
+                            {"user": site_user["name"]},
+                            {"resource_id": resid, "force": True},
+                        )
+                        ds_dropped += 1
+                    except Exception:
+                        pass
+            if ds_dropped:
+                click.secho(
+                    f"  Dropped {ds_dropped} orphaned datastore tables",
+                    fg="green",
+                )
+            else:
+                click.secho(
+                    "  No orphaned datastore tables found", fg="green"
+                )
+        except Exception as e:
+            click.secho(
+                f"  WARNING: datastore cleanup failed: {e}", fg="yellow"
+            )
+            log.warning("Datastore cleanup failed: %s", e)
+
+        # -- CSV audit report ------------------------------------------------
+        try:
+            with open(csv_path, "w", newline="") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(
+                    ["dd_id", "dd_name", "dd_state", "dv_syndicated_id"]
+                )
+                for did, dname, dstate in dataset_refs:
+                    writer.writerow(
+                        [did, dname, dstate, syndicated_ids.get(did, "")]
+                    )
+            click.secho(f"\nCSV report written to {csv_path}", fg="green")
+        except Exception as e:
+            click.secho(
+                f"\nWARNING: failed to write CSV report: {e}", fg="yellow"
+            )
+            log.warning("Failed to write CSV report to %s: %s", csv_path, e)
+
+        # -- Summary -----------------------------------------------------
+        click.secho(
+            f"\nDone. {purged} datasets purged, {failed} failed.",
+            fg="green" if failed == 0 else "yellow",
+        )
+        if syndicated_ids:
+            click.secho(
+                f"\nDD→DV cross-reference"
+                f" ({len(syndicated_ids)} syndicated datasets):",
+                fg="blue",
+            )
+            for dd_id, dv_id in sorted(syndicated_ids.items()):
+                click.secho(f"  DD {dd_id} → DV {dv_id}", fg="blue")
+        sys.stdout.flush()


### PR DESCRIPTION
[DATAVIC-822](https://digital-vic.atlassian.net/browse/DATAVIC-822): Purging DELWP Detached Datasets

This pull request enhances the DELWP dataset purge functionality in `ckanext/datavicmain/cli/maintain.py` to provide more robust reporting, notification, and cleanup. The main improvements include detailed state reporting, monitoring integration, expanded purge logic covering all dataset states, post-purge orphan cleanup, and generation of a CSV audit report.

**Improvements to reporting and monitoring:**

* The `list_detached_datasets` command now reports dataset states (active, deleted, other) and sends notifications to a monitoring service if detached datasets are found, using the `MONITOR_DELWP_DETACHED_DATASETS_URL` environment variable.

**Enhancements to purge logic and audit trail:**

* The purge operation (`purge_datasets`) now operates on all detached DELWP datasets regardless of state, collects and cross-references `syndicated_id` values for audit purposes, and generates a CSV report of purged datasets (with a configurable output path). [[1]](diffhunk://#diff-c3ce157dafca61ebd616b7a85dbed05305bd838c06dda6796fe1d80dfe0556f2L1101-R1118) [[2]](diffhunk://#diff-c3ce157dafca61ebd616b7a85dbed05305bd838c06dda6796fe1d80dfe0556f2R1178-L1143)
* Added post-purge cleanup steps: removal of orphaned Solr entries and orphaned datastore tables, with detailed reporting and error handling.

**Code and interface changes:**

* The CLI command accepts a new `--csv-path` option for specifying the CSV audit report location, defaulting to a persistent filestore path.
* Expanded imports to support new functionality, including `requests`, `os`, and additional CKAN and SQLAlchemy utilities.

**Expanded dataset selection:**

* The dataset selection logic now omits the previous filter for only active datasets, ensuring all detached DELWP datasets (active, deleted, or other) are considered for purging.

[DATAVIC-822]: https://digital-vic.atlassian.net/browse/DATAVIC-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ