### PR TITLE
Release: 2.10.6 - non-VPS publishing to DV

### DIFF
--- a/ckanext/datavicmain/iar_ckan_dataset.yaml
+++ b/ckanext/datavicmain/iar_ckan_dataset.yaml
@@ -366,7 +366,7 @@ dataset_fields:
   form_snippet: vic_custodian_autofill.html
   default_value: email
 
-- field_name: syndicate
+- field_name: skip_syndication
   display_snippet: null
   form_snippet: vic_hidden.html
   validators: default(false)

--- a/ckanext/datavicmain/migration/datavicmain_dataset/README
+++ b/ckanext/datavicmain/migration/datavicmain_dataset/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/ckanext/datavicmain/migration/datavicmain_dataset/alembic.ini
+++ b/ckanext/datavicmain/migration/datavicmain_dataset/alembic.ini
@@ -1,0 +1,74 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to ${script_location}/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat ${script_location}/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/ckanext/datavicmain/migration/datavicmain_dataset/alembic.ini.mako
+++ b/ckanext/datavicmain/migration/datavicmain_dataset/alembic.ini.mako
@@ -1,0 +1,74 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = %(here)s
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to ${script_location}/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat ${script_location}/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/ckanext/datavicmain/migration/datavicmain_dataset/env.py
+++ b/ckanext/datavicmain/migration/datavicmain_dataset/env.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+from ckan.model.meta import metadata
+
+import os
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+name = os.path.basename(os.path.dirname(__file__))
+
+
+def include_object(object, object_name, type_, reflected, compare_to):
+    if type_ == "table":
+        return object_name.startswith(name)
+    return True
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+
+    url = config.get_main_option(u"sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True,
+        version_table=u'{}_alembic_version'.format(name),
+        include_object=include_object,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix=u'sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table=u'{}_alembic_version'.format(name),
+            include_object=include_object,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/ckanext/datavicmain/migration/datavicmain_dataset/script.py.mako
+++ b/ckanext/datavicmain/migration/datavicmain_dataset/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/ckanext/datavicmain/migration/datavicmain_dataset/versions/ab7177567d5a_renamed_syndication_to_skip_syndication.py
+++ b/ckanext/datavicmain/migration/datavicmain_dataset/versions/ab7177567d5a_renamed_syndication_to_skip_syndication.py
@@ -1,0 +1,26 @@
+"""renamed syndication to skip_syndication
+
+Revision ID: ab7177567d5a
+Revises:
+Create Date: 2026-03-17 05:20:30.263834
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'ab7177567d5a'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        UPDATE package_extra
+        SET key = 'skip_syndication', value = 'false'
+        WHERE key = 'syndicate'
+    """)
+
+
+def downgrade():
+    pass

--- a/ckanext/datavicmain/plugins.py
+++ b/ckanext/datavicmain/plugins.py
@@ -448,6 +448,10 @@ class DatasetForm(
     def skip_syndication(
         self, package: model.Package, profile: Profile
     ) -> bool:
+        if package.extras.get("skip_syndication", "false") == "true":
+            log.debug("Do not syndicate %s because it is marked as skipped", package.id)
+            return True
+
         if toolkit.h.datavic_is_org_restricted(package.owner_org):
             log.debug(
                 "Do not syndicate %s because its organisation is restricted",


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-913](https://digital-vic.atlassian.net/browse/DATAVIC-913) — Rename syndicate field to skip_syndication**
- Renamed the `syndicate` field to `skip_syndication` across the extension
- Updated syndication `skip_syndication` logic to use renamed field `skip_syndication`