### PR TITLE
Release: 2.10.7 - DATAVIC-946 xloader hook

### DIFF
--- a/ckanext/datavicmain/iar_xloader_plugin.py
+++ b/ckanext/datavicmain/iar_xloader_plugin.py
@@ -1,0 +1,124 @@
+# IAR xloader: extends ckanext-xloader with new-resource-only submissions on update.
+from __future__ import annotations
+
+import logging
+
+import ckan.plugins as p
+import ckan.plugins.toolkit as toolkit
+
+from ckanext.xloader.plugin import xloaderPlugin
+
+log = logging.getLogger(__name__)
+
+
+class DatavicIARXLoaderPlugin(xloaderPlugin, p.SingletonPlugin):
+    p.implements(p.IPackageController, inherit=True)
+
+    # IPackageController
+    def after_dataset_create(self, context, pkg_dict):
+        self._trigger_after_resource_create(pkg_dict)
+
+    def after_dataset_update(self, context, pkg_dict):
+        self._submit_new_resources_only(pkg_dict)
+
+    def _submit_new_resources_only(self, pkg_dict):
+        """Submit only newly added resources to xloader during dataset update.
+
+        Compares current resource IDs against the previous activity snapshot
+        to detect new resources. URL changes for existing resources are
+        handled by the parent xloaderPlugin via ``notify()``.
+
+        Falls back to submitting all resources if no activity data is
+        available (e.g. activity plugin disabled, data migration).
+        """
+        current_resources = pkg_dict.get("resources", [])
+        current_res_ids = {
+            r.get("id") for r in current_resources if r.get("id")
+        }
+
+        previous_res_ids = self._get_previous_resource_ids(pkg_dict.get("id"))
+
+        if previous_res_ids is None:
+            log.info(
+                "No previous activity for package %s — "
+                "submitting all %d resources",
+                pkg_dict.get("id"),
+                len(current_resources),
+            )
+            for resource in current_resources:
+                self._infer_format_and_submit(resource)
+            return
+
+        new_res_ids = current_res_ids - previous_res_ids
+
+        if not new_res_ids:
+            return
+
+        log.info(
+            "Detected %d new resource(s) for package %s: %s",
+            len(new_res_ids),
+            pkg_dict.get("id"),
+            new_res_ids,
+        )
+
+        for resource in current_resources:
+            if resource.get("id") in new_res_ids:
+                self._infer_format_and_submit(resource)
+
+    def _get_previous_resource_ids(self, pkg_id):
+        """Return resource IDs from the most recent activity, or ``None``
+        if unavailable.
+        """
+        if not pkg_id or not p.plugin_loaded("activity"):
+            return None
+
+        try:
+            activities = toolkit.get_action("package_activity_list")(
+                {"ignore_auth": True},
+                {
+                    "id": pkg_id,
+                    "limit": 1,
+                    "include_hidden_activity": True,
+                },
+            )
+        except Exception:
+            return None
+
+        if not activities:
+            return None
+
+        prev_pkg = activities[0].get("data", {}).get("package", {})
+        prev_resources = prev_pkg.get("resources", [])
+        return {r.get("id") for r in prev_resources if r.get("id")}
+
+    def _infer_format_and_submit(self, resource):
+        """Infer the resource format from its URL if missing, then submit."""
+        if resource and not resource.get("format"):
+            if not resource.get("url_type"):
+                url_without_params = resource.get("url", "").split("?")[0]
+                resource["format"] = (
+                    url_without_params.split(".")[-1].lower()
+                )
+        self._submit_to_xloader(resource)
+
+    def _trigger_after_resource_create(self, pkg_dict):
+        """Submit all resources after dataset creation.
+
+        Syndication via ``package_create`` does not trigger
+        ``after_resource_create``, so we handle it here.
+        """
+        for resource in pkg_dict.get("resources", []):
+            self._infer_format_and_submit(resource)
+
+    def _submit_to_xloader(self, resource_dict):
+        """Wrapper that ensures ``url_type`` and ``format`` are present
+        before calling the parent, as they may be missing for resources
+        created inline via ``package_create``/``package_update``.
+        """
+        resource_dict.setdefault("url_type", "datavic_xloader")
+        resource_dict.setdefault("format", "")
+
+        super()._submit_to_xloader(resource_dict)
+
+        if resource_dict["url_type"] == "datavic_xloader":
+            resource_dict.pop("url_type")

--- a/ckanext/datavicmain/plugins.py
+++ b/ckanext/datavicmain/plugins.py
@@ -21,7 +21,6 @@ from ckanext.datavic_harvester.harvesters.base import get_resource_size
 from ckanext.oidc_pkce.interfaces import IOidcPkce
 from ckanext.syndicate.interfaces import ISyndicate, Profile
 from ckanext.transmute.interfaces import ITransmute
-
 from ckanext.datavicmain import cli, helpers
 from ckanext.datavicmain.implementation import PermissionLabels
 from ckanext.datavicmain.syndication.odp import prepare_package_for_odp
@@ -449,7 +448,8 @@ class DatasetForm(
         self, package: model.Package, profile: Profile
     ) -> bool:
         if package.extras.get("skip_syndication", "false") == "true":
-            log.debug("Do not syndicate %s because it is marked as skipped", package.id)
+            log.debug(
+                "Do not syndicate %s because it is marked as skipped", package.id)
             return True
 
         if toolkit.h.datavic_is_org_restricted(package.owner_org):
@@ -529,4 +529,4 @@ class DatasetForm(
         if toolkit.check_ckan_version("2.11"):
             session.modified = True
         else:
-            session.regenerate_id() # type: ignore
+            session.regenerate_id()  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         [ckan.plugins]
         datavicmain_dataset = ckanext.datavicmain.plugins:DatasetForm
         datavicmain_home = ckanext.datavicmain_home.plugins:DatavicHomePlugin
+        datavic_iar_xloader = ckanext.datavicmain.iar_xloader_plugin:DatavicIARXLoaderPlugin
+
 
         [fanstatic.libraries]
     """,


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-946](https://digital-vic.atlassian.net/browse/DATAVIC-946) — IAR xloader plugin for new-resource-only submissions**
- Added `ckanext/datavicmain/iar_xloader_plugin.py` with `DatavicIARXLoaderPlugin`, an `IXloader` implementation that only submits **newly added resources** to xloader during dataset updates (skips re-submission for existing resources)
- Registered the new plugin entry point `datavic_iar_xloader = ckanext.datavicmain.iar_xloader_plugin:DatavicIARXLoaderPlugin` in `setup.py`
- Removed the previous inline xloader hook from `ckanext/datavicmain/plugins.py` so xloader integration lives in its own plugin