### PR TITLE
[DATAVIC-968] return local org data dict instead of ckan remote.

### DIFF
--- a/ckanext/datavicmain/logic/action.py
+++ b/ckanext/datavicmain/logic/action.py
@@ -110,7 +110,7 @@ def organization_update(next_, context, data_dict):
                 file_data = f.read()
 
             patch["id"] = remote["id"]
-            return ckan.call_action(
+            ckan.call_action(
                 "organization_patch",
                 data_dict=patch,
                 files={"image_upload": (result["image_url"], file_data)},


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-968

Changes
- the chained action of `organization_update` in this ext return remote ckan data dict instead of current site result, so that the org data is not found.
- the updated code is to not return the remote ckan data, instead of returning the local site data, which is already returned in the last line of the method.