### PR TITLE
[DATAVIC-921] updated the trash view to show orgs and groups

### DIFF
--- a/ckanext/datavicmain/templates/admin/trash.html
+++ b/ckanext/datavicmain/templates/admin/trash.html
@@ -3,15 +3,15 @@
 {% block primary_content_inner %}
   {% for ent_type, entities in data.items() %}
     {% if ent_type == 'package' %}
-      <div class="accordion" id="accordion-group">
+      <div class="accordion" id="accordion-package">
         <div class="accordion-item">
-          <h2 class="accordion-header" id="heading-group">
-            <button class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#group" aria-expanded="true" aria-controls="group">
-              <i class="fa fa-group p-2"></i>
-                Deleted datasets
+          <h2 class="accordion-header" id="heading-package">
+            <button class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#package" aria-expanded="true" aria-controls="package">
+              <i class='fa fa-sitemap p-2'></i>
+                {{ _('Deleted datasets') }}
             </button>
           </h2>
-          <div id="group" class="accordion-collapse collapse show p-2" aria-labelledby="heading-group" data-bs-parent="#accordion-group">
+          <div id="package" class="accordion-collapse collapse show p-2" aria-labelledby="heading-package" data-bs-parent="#accordion-package">
             {% set truncate = truncate or 180 %}
             {% set truncate_title = truncate_title or 80 %}
             <ul class="user-list">
@@ -21,13 +21,13 @@
                   {{ h.link_to(title|truncate(truncate_title), h.url_for('dataset.read', id=pkg.name)) }}
                   <br />
                   <small><strong>Owner org ID:</strong> {{ pkg.owner_org }}</small>
-                  <a class="btn btn-danger" href="/dataset/purge/{{ pkg.id }}">Purge dataset</a>
+                  <a class="btn btn-danger" href="/dataset/purge/{{ pkg.id }}">{{ _('Purge dataset') }}</a>
                   <hr />
                 </li>
               {% else %}
-                  <li>
-                      <em>{{ _('No datasets in trash') }}</em>
-                  </li>
+                <li>
+                    <em>{{ _(messages.empty[ent_type]) }}</em>
+                </li>
               {% endfor %}
             </ul>
 
@@ -58,7 +58,7 @@
     </h2>
     <div class="module-content">
       {% trans %}
-        <p>Purge deleted datasets forever and irreversibly.</p>
+        Purge deleted datasets, organizations or groups forever and irreversibly.
       {% endtrans %}
     </div>
   </div>

--- a/ckanext/datavicmain/templates/admin/trash.html
+++ b/ckanext/datavicmain/templates/admin/trash.html
@@ -1,37 +1,53 @@
 {% extends "admin/base.html" %}
 
 {% block primary_content_inner %}
-  {% set truncate = truncate or 180 %}
-  {% set truncate_title = truncate_title or 80 %}
-  <ul class="user-list">
-    {% for pkg in data.package %}
-      {% set title = pkg.title or pkg.name %}
-      <li>
-        {{ h.link_to(title|truncate(truncate_title), h.url_for('dataset.read', id=pkg.name)) }}
-        <br />
-        <small><strong>Owner org ID:</strong> {{ pkg.owner_org }}</small>
-        <a class="btn btn-danger" href="/dataset/purge/{{ pkg.id }}">Purge dataset</a>
-        <hr />
-      </li>
+  {% for ent_type, entities in data.items() %}
+    {% if ent_type == 'package' %}
+      <div class="accordion" id="accordion-group">
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="heading-group">
+            <button class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#group" aria-expanded="true" aria-controls="group">
+              <i class="fa fa-group p-2"></i>
+                Deleted datasets
+            </button>
+          </h2>
+          <div id="group" class="accordion-collapse collapse show p-2" aria-labelledby="heading-group" data-bs-parent="#accordion-group">
+            {% set truncate = truncate or 180 %}
+            {% set truncate_title = truncate_title or 80 %}
+            <ul class="user-list">
+              {% for pkg in data.package %}
+                {% set title = pkg.title or pkg.name %}
+                <li>
+                  {{ h.link_to(title|truncate(truncate_title), h.url_for('dataset.read', id=pkg.name)) }}
+                  <br />
+                  <small><strong>Owner org ID:</strong> {{ pkg.owner_org }}</small>
+                  <a class="btn btn-danger" href="/dataset/purge/{{ pkg.id }}">Purge dataset</a>
+                  <hr />
+                </li>
+              {% else %}
+                  <li>
+                      <em>{{ _('No datasets in trash') }}</em>
+                  </li>
+              {% endfor %}
+            </ul>
+
+            <form method="POST" action="{{ h.url_for('datavic_dataset.purge_deleted_datasets') }}" class="d-flex justify-content-end">
+              {{ h.csrf_input() }}
+              <button class="btn btn-danger purge-all"
+                  type="submit"
+                  data-module="confirm-action"
+                  data-module-with-data=true
+                  data-module-content="{{ _('Are you sure you want to purge all datasets?') }}">
+                  {{ _('Purge all') }}
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
     {% else %}
-        <li>
-            <em>{{ _('No datasets in trash') }}</em>
-        </li>
-    {% endfor %}
-
-  </ul>
-
-  <form method="POST" action="{{ h.url_for('datavic_dataset.purge_deleted_datasets') }}">
-    {{ h.csrf_input() }}
-
-    <button class="btn btn-danger purge-all"
-        type="submit"
-        data-module="confirm-action"
-        data-module-with-data=true
-        data-module-content="{{ _('Are you sure you want to purge all datasets?') }}">
-        {{ _('Purge all') }}
-    </button>
-  </form>
+      {% snippet "admin/snippets/data_type.html", ent_type=ent_type, entities=entities, messages=messages %}
+    {% endif %}
+  {% endfor %}
 {% endblock %}
 
 {% block secondary_content %}


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-921

Changes
- the custom trash template is overridden, and groups and orgs are not rendered.
- I added the original snippet to render the list of deleted org and group, and maintain the customisation of the dataset listing and its custom purge endpoint.

<img width="1016" height="575" alt="image" src="https://github.com/user-attachments/assets/cf6d6fe7-f92c-497a-8280-06dcdb7c35a9" />
