### PR TITLE
Release: 2.10.11 – organisation image cleanup

### DIFF
--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import mimetypes
 import os
+import shutil
 from itertools import groupby
 from os import path, stat
 from typing import Any
@@ -23,7 +24,7 @@ import ckan.plugins.toolkit as tk
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.search import clear as search_clear
 from ckan.lib.search import rebuild
-from ckan.lib.uploader import get_resource_uploader
+from ckan.lib.uploader import get_resource_uploader, get_uploader
 from ckan.model import Resource, ResourceView
 from ckan.types import Context
 
@@ -1397,3 +1398,138 @@ class DeleteDetachedDelwpDatasets:
             for dd_id, dv_id in sorted(syndicated_ids.items()):
                 click.secho(f"  DD {dd_id} → DV {dv_id}", fg="blue")
         sys.stdout.flush()
+
+
+@maintain.command("cleanup-group-images")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="List unused images without moving them.",
+)
+def cleanup_group_images(dry_run: bool):
+    """Move unused group/organisation images to a _unused subdirectory.
+
+    Fetches all organisations and groups, collects their image_url values,
+    then compares against files on disk.  Any file not referenced by an active
+    org or group is moved to <storage_path>/_unused for safe manual review.
+    """
+    storage_path = get_uploader("group").storage_path
+
+    if dry_run:
+        click.secho("Dry-run mode — no files will be moved.", fg="blue")
+
+    try:
+        referenced = _collect_referenced_group_images()
+    except Exception as e:
+        click.secho(f"Aborting: could not collect referenced images: {e}", fg="red")
+        log.error("cleanup-group-images aborted during collection: %s", e)
+        return
+
+    click.secho(
+        f"Found {len(referenced)} referenced image filename(s) across all orgs/groups.",
+        fg="green",
+    )
+
+    if not os.path.isdir(storage_path):
+        click.secho(f"Storage path does not exist: {storage_path}", fg="red")
+        return
+
+    unused_dir = os.path.join(storage_path, "_unused")
+
+    allowed_mimetypes: list[str] = tk.config.get(
+        "ckan.upload.group.mimetypes", ["image/png", "image/gif", "image/jpeg"]
+    )
+
+    disk_files: list[str] = []
+    for filename in os.listdir(storage_path):
+        filepath = os.path.join(storage_path, filename)
+        if not os.path.isfile(filepath):
+            continue
+        mimetype, _ = mimetypes.guess_type(filename)
+        if mimetype in allowed_mimetypes:
+            disk_files.append(filename)
+
+    unused: list[str] = []
+    for filename in disk_files:
+        if filename not in referenced:
+            unused.append(filename)
+
+    if not unused:
+        click.secho("No unused images found.", fg="green")
+        return
+
+    click.secho(f"Found {len(unused)} unused image(s).", fg="yellow")
+
+    if dry_run:
+        for filename in unused:
+            click.secho(f"  Would move: {filename}", fg="yellow")
+        return
+
+    os.makedirs(unused_dir, exist_ok=True)
+
+    moved = 0
+    skipped = 0
+    failed = 0
+    for filename in unused:
+        src = os.path.join(storage_path, filename)
+        dst = os.path.join(unused_dir, filename)
+        if os.path.exists(dst):
+            click.secho(
+                f"  Skipped (already in _unused): {filename}", fg="yellow"
+            )
+            log.warning(
+                "cleanup-group-images: skipped %s — destination already exists",
+                filename,
+            )
+            skipped += 1
+            continue
+        try:
+            shutil.move(src, dst)
+            click.secho(f"  Moved: {filename}", fg="yellow")
+            moved += 1
+        except OSError as e:
+            click.secho(f"  ERROR moving {filename}: {e}", fg="red")
+            log.error("Failed to move group image %s: %s", filename, e)
+            failed += 1
+
+    click.secho(
+        f"\nDone. {moved} moved, {skipped} skipped (already in _unused),"
+        f" {failed} failed.",
+        fg="green" if failed == 0 else "yellow",
+    )
+
+
+def _collect_referenced_group_images() -> set[str]:
+    """Return the set of image filenames referenced by all orgs and groups.
+
+    Raises an exception if the top-level list call for either orgs or groups
+    fails, so the caller can abort rather than treating all files as unused.
+    """
+    ctx = {"ignore_auth": True}
+    referenced: set[str] = set()
+
+    actions = [
+        ("organization_list", "organization_show"),
+        ("group_list", "group_show"),
+    ]
+
+    for list_action, detail_action in actions:
+        names: list[str] = tk.get_action(list_action)(ctx, {"all_fields": False})
+
+        for name in names:
+            try:
+                data = tk.get_action(detail_action)(
+                    ctx, {"id": name, "include_datasets": False}
+                )
+            except Exception as e:
+                log.warning(
+                    "Could not fetch %s for %s: %s", detail_action, name, e
+                )
+                continue
+
+            value = data.get("image_url") or ""
+            if value:
+                referenced.add(value)
+
+    return referenced

--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -1530,6 +1530,6 @@ def _collect_referenced_group_images() -> set[str]:
 
             value = data.get("image_url") or ""
             if value:
-                referenced.add(value)
+                referenced.add(os.path.basename(value.rstrip("/")))
 
     return referenced

--- a/ckanext/datavicmain/cli/maintain.py
+++ b/ckanext/datavicmain/cli/maintain.py
@@ -1437,18 +1437,12 @@ def cleanup_group_images(dry_run: bool):
 
     unused_dir = os.path.join(storage_path, "_unused")
 
-    allowed_mimetypes: list[str] = tk.config.get(
-        "ckan.upload.group.mimetypes", ["image/png", "image/gif", "image/jpeg"]
-    )
-
     disk_files: list[str] = []
     for filename in os.listdir(storage_path):
         filepath = os.path.join(storage_path, filename)
         if not os.path.isfile(filepath):
             continue
-        mimetype, _ = mimetypes.guess_type(filename)
-        if mimetype in allowed_mimetypes:
-            disk_files.append(filename)
+        disk_files.append(filename)
 
     unused: list[str] = []
     for filename in disk_files:

--- a/ckanext/datavicmain/logic/action.py
+++ b/ckanext/datavicmain/logic/action.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any, cast
 
 import ckanapi
-from requests.exceptions import RequestException
 from sqlalchemy import or_
 
 import ckan.lib.plugins as lib_plugins
@@ -16,8 +15,6 @@ from ckan.logic import validate
 from ckan.types import Action, Context, DataDict
 
 from ckanext.datavic_harvester.harvesters.base import get_resource_size
-from ckanext.mailcraft.exception import MailerException
-from ckanext.mailcraft.utils import get_mailer
 from ckanext.syndicate.utils import get_profiles, get_target
 
 from ckanext.datavicmain import const, utils
@@ -124,8 +121,11 @@ def organization_update(next_, context, data_dict):
             else:
                 patch_without_image = {}
                 for k, v in patch.items():
-                    if k != "image_url":
-                        patch_without_image[k] = v
+                    if k == "image_url" and v != "":
+                        # If the image_url is not empty, we want to keep the remote image_url,
+                        # so we can exclude it from the patch.
+                        continue
+                    patch_without_image[k] = v
                 ckan.action.organization_patch(id=remote["id"], **patch_without_image)
         except Exception as e:
             log.error(

--- a/ckanext/datavicmain/logic/action.py
+++ b/ckanext/datavicmain/logic/action.py
@@ -93,7 +93,7 @@ def organization_update(next_, context, data_dict):
             remote = ckan.action.organization_show(id=old_name)
         except ckanapi.NotFound:
             continue
-        except RequestException as e:
+        except Exception as e:
             log.error(
                 f"Error updating organization {old_name} in {profile.ckan_url}: {e}"
             )
@@ -101,22 +101,33 @@ def organization_update(next_, context, data_dict):
 
         patch = {f: result[f] for f in tracked_fields if f in result}
 
-        if "image_url" in tracked_fields and result.get("image_display_url"):
-            grp_uloader: uploader.PUploader = uploader.get_uploader("group")
-            file_data = None
-            with open(
-                grp_uloader.storage_path + "/" + result["image_url"], "rb"
-            ) as f:
-                file_data = f.read()
+        image_updated = (
+            "image_url" in tracked_fields
+            and result.get("image_display_url")
+            and old.get("image_url") != result.get("image_url")
+        )
 
-            patch["id"] = remote["id"]
-            ckan.call_action(
-                "organization_patch",
-                data_dict=patch,
-                files={"image_upload": (result["image_url"], file_data)},
+        try:
+            if image_updated:
+                grp_uloader: uploader.PUploader = uploader.get_uploader("group")
+                with open(
+                    grp_uloader.storage_path + "/" + result["image_url"], "rb"
+                ) as f:
+                    file_data = f.read()
+
+                patch["id"] = remote["id"]
+                ckan.call_action(
+                    "organization_patch",
+                    data_dict=patch,
+                    files={"image_upload": (result["image_url"], file_data)},
+                )
+            else:
+                ckan.action.organization_patch(id=remote["id"], **patch)
+        except Exception as e:
+            log.error(
+                f"Error patching organization {old_name} in {profile.ckan_url}: {e}"
             )
-        else:
-            ckan.action.organization_patch(id=remote["id"], **patch)
+            continue
 
     return result
 

--- a/ckanext/datavicmain/logic/action.py
+++ b/ckanext/datavicmain/logic/action.py
@@ -109,9 +109,9 @@ def organization_update(next_, context, data_dict):
 
         try:
             if image_updated:
-                grp_uloader: uploader.PUploader = uploader.get_uploader("group")
+                grp_uploader: uploader.PUploader = uploader.get_uploader("group")
                 with open(
-                    grp_uloader.storage_path + "/" + result["image_url"], "rb"
+                    grp_uploader.storage_path + "/" + result["image_url"], "rb"
                 ) as f:
                     file_data = f.read()
 
@@ -122,7 +122,11 @@ def organization_update(next_, context, data_dict):
                     files={"image_upload": (result["image_url"], file_data)},
                 )
             else:
-                ckan.action.organization_patch(id=remote["id"], **patch)
+                patch_without_image = {}
+                for k, v in patch.items():
+                    if k != "image_url":
+                        patch_without_image[k] = v
+                ckan.action.organization_patch(id=remote["id"], **patch_without_image)
         except Exception as e:
             log.error(
                 f"Error patching organization {old_name} in {profile.ckan_url}: {e}"


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-959](https://digital-vic.atlassian.net/browse/DATAVIC-959) — Duplicate organisation images on DV filestore**

- `organization_update` (chained action, `logic/action.py`) now re-uploads the organisation image to each syndication target only when the image actually changed — `old["image_url"] != result["image_url"]`. Previously every organisation update posted `image_upload` to `organization_patch`, and the DV uploader wrote a new uniquely named file each time.
- When the image is unchanged, the remote is patched without `image_url` (a non-empty `image_url` is dropped from the patch payload) so the existing remote image and filename are retained. An empty `image_url` is still sent, so clearing the image on DD still clears it on DV.
- The remote patch call is wrapped in `try`/`except Exception`, logging the failure and continuing to the next profile instead of raising.
- `organization_show` on the remote now catches `Exception` rather than `RequestException`, so non-HTTP `ckanapi` failures no longer abort the update.
- Removed the unused `ckanext.mailcraft` imports (`MailerException`, `get_mailer`) and the now-unused `requests.exceptions.RequestException` import.
- New `ckan maintain cleanup-group-images` CLI command (`cli/maintain.py`): collects `image_url` filenames from every organisation and group via `organization_list`/`organization_show` and `group_list`/`group_show`, then moves any file in the `group` uploader storage path that is not referenced into a `_unused` subdirectory for manual review.
- `--dry-run` lists the unused files without moving them. A failure of the top-level list call aborts before anything is moved, so a partial read cannot mark live images as unused. Files already present in `_unused` are skipped, per-file `OSError` is logged and counted, and a moved / skipped / failed tally is printed.


[DATAVIC-959]: https://digital-vic.atlassian.net/browse/DATAVIC-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ